### PR TITLE
Allow the script to print the results on stdout as well

### DIFF
--- a/report-topk-partion-sizes
+++ b/report-topk-partion-sizes
@@ -257,16 +257,6 @@ class EmailMessage(object):
             <td>https://github.com/eevans/services-adhoc-reports</td>
           </tr>
         </table>
-
-        <p class="notice">
-          <i>
-            Note: This (beta) report is currently being generated from an adhoc Git checkout in a user
-            home directory, and is executed by a manually configured cron job.  If accepted, this software
-            should be properly documented, deployed, and Puppetized (see
-            <a href="https://phabricator.wikimedia.org/T147366">Setup automated topk wide row reporting</a>
-            for more information).
-          </i>
-        </p>
       </body>
     </html>
     """
@@ -314,14 +304,20 @@ class EmailMessage(object):
             raise Exception("invalid message")
         self.message.attach(message)
 
+def write_csv(stream, results):
+    """
+    Writes the results in CSV format to the specified stream
+    """
+    csv_writer = csv.writer(stream)
+    for res in results:
+        csv_writer.writerow([res[0].encode("utf-8"), res[1]])
+
 def csv_attachement(results):
     """
     Return an email attachment of a csv file containing results.
     """
     csv_fp = StringIO.StringIO()
-    csv_writer = csv.writer(csv_fp)
-    for res in results:
-        csv_writer.writerow([res[0].encode("utf-8"), res[1]])
+    write_csv(csv_fp, results)
     csv_msg = MIMEText(csv_fp.getvalue(), "csv")
     csv_msg.add_header("Content-Disposition", "attachment", filename="report.csv")
     return csv_msg
@@ -351,13 +347,58 @@ def strfsize(num, suffix='B'):
         num /= 1024.0
     return "%.1f%s%s" % (num, 'Yi', suffix)
 
+def pretty_print(values):
+    """
+    Writes the report as a pretty-formatted list on stdout
+    """
+    header = ['Size', 'Partition', 'Size (in bytes)']
+    size = [len(x) for x in header]
+    results = []
+    # format the values and find out the largest element in each column
+    for val in values:
+        tup = (strfsize(val[1]), val[0], str(val[1]))
+        for idx, slen in enumerate(size):
+            if len(tup[idx]) > slen:
+                size[idx] = len(tup[idx])
+        results.append(tup)
+    results.insert(0, header)
+    # adjust the width of each cell
+    results = [[res[idx].ljust(s) for idx, s in enumerate(size)] for res in results]
+    # print it out
+    for res in results:
+        sys.stdout.write('%s  %s  %s\n' % (res[0], res[1], res[2]))
+
+def send_email(values, args, count, exec_start_time):
+    """
+    Create and send the report in an e-mail
+    """
+    print "Sending email report..."
+    # Craft an html email message report.
+    email = EmailMessage(
+        results=[(i[0], strfsize(i[1])) for i in values[:args.top]],
+        subject=subject(args.last_days),
+        email_address=args.email,
+        message_from="{}@{}".format(getpass.getuser(), local_hostname()),
+        cluster_name=args.cluster,
+        logstash_host=args.logstash_host,
+        execution_host=local_hostname(),
+        execution_time=time.time()-exec_start_time,
+        total_query_results=count,
+        unique_query_results=len(values)
+    )
+    email.attach(csv_attachement(values[:args.top]))    # Attach a csv file.
+    email.send()                                        # Deliver.
+    print "Done."
+
 def parse_arguments():
     """
     Parse command-line arguments.
     """
     parser = argparse.ArgumentParser(
         description="Generate an email report of the widest Cassandra partitions.")
-    parser.add_argument("-e", "--email", metavar="ADDRESS", required=True, help="Email address to send report to")
+    parser.add_argument("-e", "--email", metavar="ADDRESS", default='', help="Email the report to the specified address")
+    parser.add_argument('-s', '--csv', action='store_true', help='Output a comma-delimited report to stdout')
+    parser.add_argument('-t', '--printed', action='store_true', help='Output a pretty-formatted report to stdout')
     parser.add_argument(
         "-H", "--logstash-host",
         metavar="HOST",
@@ -368,7 +409,11 @@ def parse_arguments():
     parser.add_argument("-c", "--cluster", metavar="NAME", default="eqiad", help="Cassandra cluster name")
     parser.add_argument(
         "-d", "--last-days", metavar="DAYS", default=7, type=int, help="Past number of days to report on")
-    return parser.parse_args()
+    ret = parser.parse_args()
+    if not (ret.csv or ret.printed or len(ret.email)):
+        sys.stderr.write('One of --email, --csv or --printed has to be supplied!\n')
+        sys.exit(2)
+    return ret
 
 def main():
     """
@@ -408,27 +453,16 @@ def main():
     # Sort results by partition size, descending.
     values = sorted(results.items(), key=operator.itemgetter(1), reverse=True)
 
-    print "Sending email report..."
-
-    # Craft an html email message report.
-    email = EmailMessage(
-        results=[(i[0], strfsize(i[1])) for i in values[:args.top]],
-        subject=subject(args.last_days),
-        email_address=args.email,
-        message_from="{}@{}".format(getpass.getuser(), local_hostname()),
-        cluster_name=args.cluster,
-        logstash_host=args.logstash_host,
-        execution_host=local_hostname(),
-        execution_time=time.time()-exec_start_time,
-        total_query_results=count,
-        unique_query_results=len(values)
-    )
-
-    email.attach(csv_attachement(values[:args.top]))    # Attach a csv file.
-    email.send()                                        # Deliver.
-
-    print "Done."
-
+    # decide on the action to perform
+    if len(args.email):
+        # send the e-mail
+        send_email(values, args, count, exec_start_time)
+    elif args.csv:
+        # print the CSV on stdout
+        write_csv(sys.stdout, values[:args.top])
+    elif args.printed:
+        # pretty-print the results
+        pretty_print(values[:args.top])
 
 if __name__ == "__main__":
     main()

--- a/report-topk-partion-sizes
+++ b/report-topk-partion-sizes
@@ -399,7 +399,6 @@ def parse_arguments():
         description="Generate an email report of the widest Cassandra partitions.")
     parser.add_argument("-e", "--email", metavar="ADDRESS", default='', help="Email the report to the specified address")
     parser.add_argument('-s', '--csv', action='store_true', help='Output a comma-delimited report to stdout')
-    parser.add_argument('-t', '--printed', action='store_true', help='Output a pretty-formatted report to stdout')
     parser.add_argument(
         "-H", "--logstash-host",
         metavar="HOST",
@@ -410,11 +409,7 @@ def parse_arguments():
     parser.add_argument("-c", "--cluster", metavar="NAME", default="eqiad", help="Cassandra cluster name")
     parser.add_argument(
         "-d", "--last-days", metavar="DAYS", default=7, type=int, help="Past number of days to report on")
-    ret = parser.parse_args()
-    if not (ret.csv or ret.printed or len(ret.email)):
-        sys.stderr.write('One of --email, --csv or --printed has to be supplied!\n')
-        sys.exit(2)
-    return ret
+    return parser.parse_args()
 
 def main():
     """
@@ -461,7 +456,7 @@ def main():
     elif args.csv:
         # print the CSV on stdout
         write_csv(sys.stdout, values[:args.top])
-    elif args.printed:
+    else:
         # pretty-print the results
         pretty_print(values[:args.top])
 

--- a/report-topk-partion-sizes
+++ b/report-topk-partion-sizes
@@ -33,6 +33,7 @@ import StringIO
 import socket
 import sys
 import time
+import logging
 
 from email.mime.text      import MIMEText
 from email.mime.base      import MIMEBase
@@ -372,7 +373,7 @@ def send_email(values, args, count, exec_start_time):
     """
     Create and send the report in an e-mail
     """
-    print "Sending email report..."
+    logging.warning("Sending email report...")
     # Craft an html email message report.
     email = EmailMessage(
         results=[(i[0], strfsize(i[1])) for i in values[:args.top]],
@@ -388,7 +389,7 @@ def send_email(values, args, count, exec_start_time):
     )
     email.attach(csv_attachement(values[:args.top]))    # Attach a csv file.
     email.send()                                        # Deliver.
-    print "Done."
+    logging.warning("Done.")
 
 def parse_arguments():
     """
@@ -430,7 +431,7 @@ def main():
 
     # Query each daily logstash index, for the last N days.
     for index in index_names(args.last_days):
-        print "Querying elasticsearch index:", index
+        logging.warning("Querying elasticsearch index: %s" % index)
         try:
             # Collate the returned results.
             for hit in logstash.search(index, search_query(args.cluster)):
@@ -438,7 +439,7 @@ def main():
                 message = hit["_source"]["message"]
                 match = log_message_re.match(message)
                 if not match:
-                    print "Warning: result did not match regex (\"{}\")".format(message)
+                    logging.error("Result did not match regex (\"{}\")".format(message))
                     continue
                 partition = match.group("partition")
                 size = match.group("bytes")
@@ -448,7 +449,7 @@ def main():
         # (an elasticsearch setting; 10000 in our environment).  The solution seems to be to use the
         # scroll API instead (https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-scroll.html).
         except Exception, err:
-            print >>sys.stderr, "Query of index {} failed: {}".format(index, err)
+            logging.error("Query of index {} failed: {}".format(index, err))
 
     # Sort results by partition size, descending.
     values = sorted(results.items(), key=operator.itemgetter(1), reverse=True)
@@ -465,4 +466,5 @@ def main():
         pretty_print(values[:args.top])
 
 if __name__ == "__main__":
+    logging.basicConfig(stream=sys.stderr, level=logging.WARNING)
     main()


### PR DESCRIPTION
Apart from sending the e-mail, the script should also be able to print the results on stdout so that an operator can run the script on demand without too much e-mail traffic.

This PR adds two such modes: csv and pretty-printed.